### PR TITLE
Depend on the release version of ice4j 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>ice4j</artifactId>
-        <version>1.0-20151202.233708-16</version>
+        <version>1.0</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Modifies the .pom file to reference the release version of ice4j 1.0, not the snapshot.
